### PR TITLE
Set crunch/fastcgi to '2.x-dev' from 'dev-master'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"php" : ">=5.4.0",
 		"rhumsaa/uuid" : "~2.8",
 		"psr/log" : "*",
-		"crunch/fastcgi" : "dev-master",
+		"crunch/fastcgi" : "2.x-dev",
 		"appserver-io/server" : "~10.0",
 		"appserver-io/http" : "~2.0",
 		"appserver-io/fastcgi" : "~1.0",


### PR DESCRIPTION
I'll drop PHP5.x support and require PHP7+ some day (depending on free time and motivation). To avoid confusion I'll release it as "3.x" (although there were never an official 2.x-release). For you this means, that you should rely on the specific branch-alias for the 2.x-branch instead of `master`. Currently `master` and `2.x-dev` are identical.

Note: That newline at the end of the file was added by github, but a missing newline can confuse some diff-tools, so it's recommended anyway
